### PR TITLE
feat: warn on REMOTE clock manipulation. fixes #17

### DIFF
--- a/source/runtime/CamundaClock.ts
+++ b/source/runtime/CamundaClock.ts
@@ -1,9 +1,17 @@
+import Debug from 'debug'
+
 import { CamundaProcessTestRuntime } from './CamundaProcessTestRuntime'
+
+const clockWarn = Debug('camunda:test:clock')
+clockWarn.enabled = true
 
 /**
  * Utility class for managing Zeebe's clock in test environments.
  * Uses the undocumented /actuator/clock REST API endpoints.
  * Properly handles container host resolution for cross-platform compatibility.
+ *
+ * ⚠️  IMPORTANT: Clock manipulation may fail in REMOTE mode (SaaS/C8Run environments).
+ * For reliable timer testing, use MANAGED mode with Docker containers.
  */
 export class CamundaClock {
 	private readonly managementBaseUrl: string
@@ -28,42 +36,80 @@ export class CamundaClock {
 	}
 
 	/**
-	 * Advance the clock by the specified number of milliseconds
+	 * Advance the clock by the specified number of milliseconds.
+	 *
+	 * ⚠️  Warning: May fail in REMOTE mode (SaaS/C8Run). Use MANAGED mode for reliable timer testing.
 	 */
 	async addTime(offsetMillis: number): Promise<void> {
-		const response = await fetch(`${this.managementBaseUrl}/add`, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({ offsetMilli: offsetMillis }),
-		})
-
-		if (!response.ok) {
-			throw new Error(
-				`Failed to advance clock: ${response.status} ${response.statusText}`
+		const runtimeMode = this.runtime.getRuntimeMode()
+		if (runtimeMode === 'REMOTE') {
+			clockWarn(
+				'⚠️  REMOTE mode: Clock manipulation may fail on SaaS/C8Run. Consider using MANAGED mode for timer tests.'
 			)
+		}
+
+		try {
+			const response = await fetch(`${this.managementBaseUrl}/add`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ offsetMilli: offsetMillis }),
+			})
+
+			if (!response.ok) {
+				throw new Error(
+					`Failed to advance clock: ${response.status} ${response.statusText}`
+				)
+			}
+		} catch (error) {
+			if (runtimeMode === 'REMOTE') {
+				throw new Error(
+					`❌ Clock manipulation failed in REMOTE mode. SaaS and C8Run environments typically reject clock changes. Use MANAGED mode (Docker containers) for reliable timer testing. Original error: ${error}`
+				)
+			}
+			throw error
 		}
 	}
 
 	/**
-	 * Reset the clock to the system time
+	 * Reset the clock to the system time.
+	 *
+	 * ⚠️  Warning: May fail in REMOTE mode (SaaS/C8Run). Use MANAGED mode for reliable timer testing.
 	 */
 	async resetClock(): Promise<void> {
-		const response = await fetch(this.managementBaseUrl, {
-			method: 'DELETE',
-		})
-
-		if (!response.ok) {
-			throw new Error(
-				`Failed to reset clock: ${response.status} ${response.statusText}`
+		const runtimeMode = this.runtime.getRuntimeMode()
+		if (runtimeMode === 'REMOTE') {
+			clockWarn(
+				'⚠️  REMOTE mode: Clock reset may fail on SaaS/C8Run. Consider using MANAGED mode for timer tests.'
 			)
+		}
+
+		try {
+			const response = await fetch(this.managementBaseUrl, {
+				method: 'DELETE',
+			})
+
+			if (!response.ok) {
+				throw new Error(
+					`Failed to reset clock: ${response.status} ${response.statusText}`
+				)
+			}
+		} catch (error) {
+			if (runtimeMode === 'REMOTE') {
+				throw new Error(
+					`❌ Clock reset failed in REMOTE mode. SaaS and C8Run environments typically reject clock changes. Use MANAGED mode (Docker containers) for reliable timer testing. Original error: ${error}`
+				)
+			}
+			throw error
 		}
 	}
 
 	/**
 	 * Advance the clock by the specified duration.
 	 * Supports common time units.
+	 *
+	 * ⚠️  Warning: May fail in REMOTE mode (SaaS/C8Run). Use MANAGED mode for reliable timer testing.
 	 */
 	async advanceTime(
 		amount: number,
@@ -74,6 +120,13 @@ export class CamundaClock {
 			| 'hours'
 			| 'days' = 'milliseconds'
 	): Promise<void> {
+		const runtimeMode = this.runtime.getRuntimeMode()
+		if (runtimeMode === 'REMOTE') {
+			clockWarn(
+				`⚠️  REMOTE mode: Advancing clock by ${amount} ${unit} may fail on SaaS/C8Run. Consider using MANAGED mode for timer tests.`
+			)
+		}
+
 		let milliseconds = amount
 
 		switch (unit) {

--- a/source/runtime/CamundaProcessTestRuntime.ts
+++ b/source/runtime/CamundaProcessTestRuntime.ts
@@ -197,6 +197,10 @@ export class CamundaProcessTestRuntime {
 		return this.container as unknown as CamundaContainer
 	}
 
+	getRuntimeMode(): 'MANAGED' | 'REMOTE' {
+		return this.config.runtimeMode || 'MANAGED'
+	}
+
 	getMonitoringApiPort(): number {
 		if (this.config.runtimeMode === 'REMOTE') {
 			if (this.remoteMonitoringApiAddress) {


### PR DESCRIPTION
This PR adds warning functionality when attempting to manipulate Zeebe's clock in REMOTE mode (SaaS/C8Run environments), addressing issue https://github.com/jwulf/camunda-process-test-js/issues/17. The changes help users understand that clock manipulation may fail in cloud environments and should use MANAGED mode with Docker containers for reliable timer testing.

Key changes:

- Added runtime mode detection and warning messages for clock manipulation operations
- Enhanced error handling with specific guidance for REMOTE mode failures
- Updated documentation to clarify testing strategies for different runtime modes

Users will now receive clear, actionable guidance when attempting clock manipulation in REMOTE mode, helping them understand the limitations and choose the appropriate testing strategy.

Signed-off-by: Josh Wulf <josh.wulf@camunda.com>